### PR TITLE
EI-379 build ensure released docker images are stored to our ftp aside distributions

### DIFF
--- a/build_parameters.json
+++ b/build_parameters.json
@@ -76,25 +76,25 @@
 							"ORIGIN": "step-distribution-parent/step-distribution-controller/target/step-controller-${VERSION}.zip",
 							"DESTINATION": "step/controller:${VERSION}-java-11",
 							"CONFIG": "controller-11-dockerfile",
-							"FTP_DESTINATION": "step/${VERSION}/images/step-controller-${VERSION}-java-11.tar.gz"
+							"IMAGE_BASENAME": "step-controller-${VERSION}-java-11"
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-agent/target/step-agent-${VERSION}.zip",
 							"DESTINATION": "step/agent:${VERSION}-java-11",
 							"CONFIG": "agent-11-dockerfile",
-							"FTP_DESTINATION": "step/${VERSION}/images/step-agent-${VERSION}-java-11.tar.gz"
+							"IMAGE_BASENAME": "step-agent-${VERSION}-java-11"
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-controller/target/step-controller-${VERSION}.zip",
 							"DESTINATION": "step/controller:${VERSION}-java-17",
 							"CONFIG": "controller-17-dockerfile",
-							"FTP_DESTINATION": "step/${VERSION}/images/step-controller-${VERSION}-java-17.tar.gz"
+							"IMAGE_BASENAME": "step-controller-${VERSION}-java-17"
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-agent/target/step-agent-${VERSION}.zip",
 							"DESTINATION": "step/agent:${VERSION}-java-17",
 							"CONFIG": "agent-17-dockerfile",
-							"FTP_DESTINATION": "step/${VERSION}/images/step-agent-${VERSION}-java-17.tar.gz"
+							"IMAGE_BASENAME": "step-agent-${VERSION}-java-17"
 						}
 					]
 				}

--- a/build_parameters.json
+++ b/build_parameters.json
@@ -116,7 +116,7 @@
 					"DOMAIN": "stepcloud-test.ch",
 					"IMAGE_REPOSITORY": "docker-dev.exense.ch/step",
 					"PERSISTENCE": "false",
-					"CHART_VERSION": "0.0.15-SNAPSHOT"
+					"CHART_VERSION": "0.0.16-SNAPSHOT"
 				},
 				{
 					"NAME": "INTEGRATION",
@@ -126,7 +126,7 @@
 					"DOMAIN": "stepcloud-test.ch",
 					"IMAGE_REPOSITORY": "docker-dev.exense.ch/step",
 					"PERSISTENCE": "false",
-					"CHART_VERSION": "0.0.15-SNAPSHOT"
+					"CHART_VERSION": "0.0.16-SNAPSHOT"
 				}
 			]
 		}

--- a/build_parameters.json
+++ b/build_parameters.json
@@ -75,22 +75,26 @@
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-controller/target/step-controller-${VERSION}.zip",
 							"DESTINATION": "step/controller:${VERSION}-java-11",
-							"CONFIG": "controller-11-dockerfile"
+							"CONFIG": "controller-11-dockerfile",
+							"FTP_DESTINATION": "step/${VERSION}/images/step-controller-${VERSION}-java-11.tar.gz"
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-agent/target/step-agent-${VERSION}.zip",
 							"DESTINATION": "step/agent:${VERSION}-java-11",
-							"CONFIG": "agent-11-dockerfile"
+							"CONFIG": "agent-11-dockerfile",
+							"FTP_DESTINATION": "step/${VERSION}/images/step-agent-${VERSION}-java-11.tar.gz"
 						},
-												{
+						{
 							"ORIGIN": "step-distribution-parent/step-distribution-controller/target/step-controller-${VERSION}.zip",
 							"DESTINATION": "step/controller:${VERSION}-java-17",
-							"CONFIG": "controller-17-dockerfile"
+							"CONFIG": "controller-17-dockerfile",
+							"FTP_DESTINATION": "step/${VERSION}/images/step-controller-${VERSION}-java-17.tar.gz"
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-agent/target/step-agent-${VERSION}.zip",
 							"DESTINATION": "step/agent:${VERSION}-java-17",
-							"CONFIG": "agent-17-dockerfile"
+							"CONFIG": "agent-17-dockerfile",
+							"FTP_DESTINATION": "step/${VERSION}/images/step-agent-${VERSION}-java-17.tar.gz"
 						}
 					]
 				}

--- a/build_parameters.json
+++ b/build_parameters.json
@@ -76,25 +76,29 @@
 							"ORIGIN": "step-distribution-parent/step-distribution-controller/target/step-controller-${VERSION}.zip",
 							"DESTINATION": "step/controller:${VERSION}-java-11",
 							"CONFIG": "controller-11-dockerfile",
-							"IMAGE_BASENAME": "step-controller-${VERSION}-java-11"
+							"IMAGE_BASENAME": "step-controller-${VERSION}-java-11",
+							"SHARE_ON_FTP": false
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-agent/target/step-agent-${VERSION}.zip",
 							"DESTINATION": "step/agent:${VERSION}-java-11",
 							"CONFIG": "agent-11-dockerfile",
-							"IMAGE_BASENAME": "step-agent-${VERSION}-java-11"
+							"IMAGE_BASENAME": "step-agent-${VERSION}-java-11",
+							"SHARE_ON_FTP": false
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-controller/target/step-controller-${VERSION}.zip",
 							"DESTINATION": "step/controller:${VERSION}-java-17",
 							"CONFIG": "controller-17-dockerfile",
-							"IMAGE_BASENAME": "step-controller-${VERSION}-java-17"
+							"IMAGE_BASENAME": "step-controller-${VERSION}-java-17",
+							"SHARE_ON_FTP": true
 						},
 						{
 							"ORIGIN": "step-distribution-parent/step-distribution-agent/target/step-agent-${VERSION}.zip",
 							"DESTINATION": "step/agent:${VERSION}-java-17",
 							"CONFIG": "agent-17-dockerfile",
-							"IMAGE_BASENAME": "step-agent-${VERSION}-java-17"
+							"IMAGE_BASENAME": "step-agent-${VERSION}-java-17",
+							"SHARE_ON_FTP": true
 						}
 					]
 				}


### PR DESCRIPTION
To be used with the new version of the Docker PUSH plan, available at https://build.stepcloud-test.ch/#/plans/editor/618aa49f34603040f758fd0d?tenant=build